### PR TITLE
Fix build failed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,11 +14,12 @@ NAME2 = my_torch_analyzer
 all: compile
 
 compile:
-	cd torch_generator && cargo build && cd .. ; \
-	cd torch_analyzer && cargo build && cd .. ; \
-	mv debug/$(NAME1) .
-	mv debug/$(NAME2) .
+	cd torch_generator && cargo build --release --offline && cd .. ; \
+	cd torch_analyzer && cargo build --release --offline && cd .. ; \
+	cp release/$(NAME1) .
+	cp release/$(NAME2) .
 	rm -rf debug
+	rm -rf release
 	rm -f .rustc_info.json
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 ##
 ## EPITECH PROJECT, 2024
-## Gomoku
+## My_Torch
 ## File description:
 ## Makefile
 ##

--- a/torch_analyzer/Cargo.toml
+++ b/torch_analyzer/Cargo.toml
@@ -3,6 +3,5 @@ name = "my_torch_analyzer"
 version = "0.1.0"
 edition = "2021"
 
-[dependencies]
-
+[dev-dependencies]
 once_cell = "1.10.0"


### PR DESCRIPTION
Fix the compilation on the Epitech Mouli.
The binaries are now compile offline to avoid extern dependencies download.
The tests still be compile as before.